### PR TITLE
Make the API more "rustful"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ pub use self::modbus_rtu::{ModbusRTU, RequestToSendMode, SerialMode};
 pub use self::modbus_server::ModbusServer;
 pub use self::modbus_tcp_pi::ModbusTCPPI;
 pub use self::modbus_tcp::ModbusTCP;
-pub use self::modbus::Modbus;
+pub use self::modbus::{Modbus, Timeout};
 pub use self::modbus::{set_bits_from_byte, set_bits_from_bytes, get_byte_from_bits,
     get_float_abcd, set_float_abcd, get_float_badc, set_float_badc,
     get_float_cdab, set_float_cdab, get_float_dcba, set_float_dcba,


### PR DESCRIPTION
Update the modbus.rs API to make it more "rustful" by:
 * Returning empty Results over fixed zero ints
 * Better converting result values.
 * Not passing in empty mutable values on get_* methods
 * Checking explicitly for 0 result values

This is the start of the work I would like to do and not yet completed. I am seeking comments of what you think about the API change?