### PR TITLE
Bump bindgen version to 0.62.0

### DIFF
--- a/libmodbus-sys/Cargo.toml
+++ b/libmodbus-sys/Cargo.toml
@@ -21,6 +21,6 @@ path = "lib.rs"
 libc = "0.2.80"
 
 [build-dependencies]
-bindgen = "0.55.1"
+bindgen = "0.62.0"
 cc = "1.0"
 pkg-config = "0.3.19"

--- a/libmodbus-sys/build.rs
+++ b/libmodbus-sys/build.rs
@@ -121,7 +121,7 @@ fn run_bindgen(include: &PathBuf) {
         .header("wrapper.h")
         .clang_arg(format!("-I{}", include.display()))
         .bitfield_enum("modbus_error_recovery_mode")
-        .blacklist_type("_?P?IMAGE_TLS_DIRECTORY.*")
+        .blocklist_type("_?P?IMAGE_TLS_DIRECTORY.*")
         .generate()
         .expect("could not reate binding");
 


### PR DESCRIPTION
There has was a change since clang16 that makes broke bindgen<0.62. This issue is tracked in [#2312](https://github.com/rust-lang/rust-bindgen/issues/2312).

This pull-request updates the dependency version in libmodbus-sys.

Additionally, blacklist_type was deprecated in bindgen 0.62 and changed to blocklist_type. Changes to build.rs are included.

Previous pull request was from and to wrong branch. Sorry about the spam.

